### PR TITLE
Use position independent code (-fPIC)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,8 @@ test-with-tiny-model = []
 
 [package.metadata.docs.rs]
 features = ["simd"]
+
+[[example]]
+name = "cdylib"
+path = "examples/cdylib.rs"
+crate-type = ["cdylib"]

--- a/examples/cdylib.rs
+++ b/examples/cdylib.rs
@@ -1,0 +1,68 @@
+#![allow(clippy::uninlined_format_args)]
+
+use whisper_rs::{FullParams, SamplingStrategy, WhisperContext};
+
+// this example does not do anything, it is a demonstration
+// that you can build whisper into a cdylib.
+pub fn usage() -> Result<(), &'static str> {
+    // load a context and model
+    let ctx = WhisperContext::new("path/to/model").expect("failed to load model");
+    // make a state
+    let mut state = ctx.create_state().expect("failed to create state");
+
+    // create a params object
+    // note that currently the only implemented strategy is Greedy, BeamSearch is a WIP
+    // n_past defaults to 0
+    let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
+
+    // edit things as needed
+    // here we set the number of threads to use to 1
+    params.set_n_threads(1);
+    // we also enable translation
+    params.set_translate(true);
+    // and set the language to translate to to english
+    params.set_language(Some("en"));
+    // we also explicitly disable anything that prints to stdout
+    params.set_print_special(false);
+    params.set_print_progress(false);
+    params.set_print_realtime(false);
+    params.set_print_timestamps(false);
+
+    // assume we have a buffer of audio data
+    // here we'll make a fake one, integer samples, 16 bit, 16KHz, stereo
+    let audio_data = vec![0_i16; 16000 * 2];
+
+    // we must convert to 16KHz mono f32 samples for the model
+    // some utilities exist for this
+    // note that you don't need to use these, you can do it yourself or any other way you want
+    // these are just provided for convenience
+    // SIMD variants of these functions are also available, but only on nightly Rust: see the docs
+    let audio_data = whisper_rs::convert_stereo_to_mono_audio(
+        &whisper_rs::convert_integer_to_float_audio(&audio_data),
+    )?;
+
+    // now we can run the model
+    // note the key we use here is the one we created above
+    state
+        .full(params, &audio_data[..])
+        .expect("failed to run model");
+
+    // fetch the results
+    let num_segments = state
+        .full_n_segments()
+        .expect("failed to get number of segments");
+    for i in 0..num_segments {
+        let segment = state
+            .full_get_segment_text(i)
+            .expect("failed to get segment");
+        let start_timestamp = state
+            .full_get_segment_t0(i)
+            .expect("failed to get segment start timestamp");
+        let end_timestamp = state
+            .full_get_segment_t1(i)
+            .expect("failed to get segment end timestamp");
+        println!("[{} - {}]: {}", start_timestamp, end_timestamp, segment);
+    }
+
+    Ok(())
+}

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -104,6 +104,8 @@ fn main() {
     #[cfg(feature = "opencl")]
     cmd.arg("-DWHISPER_CLBLAST=ON");
 
+    cmd.arg("-DCMAKE_POSITION_INDEPENDENT_CODE=ON");
+
     let code = cmd
         .status()
         .expect("Failed to run `cmake` (is CMake installed?)");


### PR DESCRIPTION
This allows whipser-rs-sys to work when building a cdylib on x86 Linux.

Without this change, linking fails with:

```
  = note: /usr/bin/ld: /.../target/debug/deps/libwhisper_rs_sys-d9be91f496c91a32.rlib(whisper.cpp.o): warning: relocation against `_ZTVNSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEEE@@GLIBCXX_3.4.21' in read-only section `.text.unlikely'
          /usr/bin/ld: /.../target/debug/deps/libwhisper_rs_sys-d9be91f496c91a32.rlib(whisper.cpp.o): relocation R_X86_64_PC32 against symbol `stderr@@GLIBC_2.2.5' can not be used when making a shared object; recompile with -fPIC
          /usr/bin/ld: final link failed: bad value
          collect2: error: ld returned 1 exit status
```